### PR TITLE
Moznost vice zdroju dat

### DIFF
--- a/_infografiky/emise/emise-cr-detail.md
+++ b/_infografiky/emise/emise-cr-detail.md
@@ -6,7 +6,10 @@ weight:     4
 tags:       [ emise, CO2, CR ]
 caption:    "Rozložení celkových emisí skleníkových plynů (v tunách CO<sub>2</sub> ekvivalentu) v ČR za jeden rok v jednotlivých sektorech lidské činnosti. Roční objem emisí České republiky je 130,35 mil. tun (údaj z roku 2016). V přepočtu na obyvatele to je 12,3 tCO<sub>2</sub>eq/obyvatele."
 data-our:   "https://docs.google.com/spreadsheets/d/1igCIcrkec7J6sfp4L4lGMzeDS4Mf-o7GZOxduZC8-pc/edit?usp=sharing"
-data-orig:	[ [ "Zdrojová data Eurostat", "http://appsso.eurostat.ec.europa.eu/nui/show.do?query=BOOKMARK_DS-089165_QID_20FB36E9_UID_-3F171EB0&layout=GEO,L,X,0;AIREMSECT,B,Y,0;UNIT,L,Z,0;AIRPOL,L,Z,1;TIME,C,Z,2;INDICATORS,C,Z,3;&zSelection=DS-089165INDICATORS,OBS_FLAG;DS-089165TIME,2016;DS-089165UNIT,MIO_T;DS-089165AIRPOL,GHG;&rankName1=UNIT_1_2_-1_2&rankName2=AIRPOL_1_2_-1_2&rankName3=INDICATORS_1_2_-1_2&rankName4=TIME_1_0_0_0&rankName5=GEO_1_2_0_0&rankName6=AIREMSECT_1_2_0_1&rStp=&cStp=&rDCh=&cDCh=&rDM=true&cDM=true&footnes=false&empty=false&wai=false&time_mode=NONE&time_most_recent=false&lang=EN&cfo=%23%23%23.%23%23%23%2C%23%23%23" ] ]
+data-orig:  [
+              [ "Eurostat", "http://appsso.eurostat.ec.europa.eu/nui/show.do?query=BOOKMARK_DS-089165_QID_20FB36E9_UID_-3F171EB0&layout=GEO,L,X,0;AIREMSECT,B,Y,0;UNIT,L,Z,0;AIRPOL,L,Z,1;TIME,C,Z,2;INDICATORS,C,Z,3;&zSelection=DS-089165INDICATORS,OBS_FLAG;DS-089165TIME,2016;DS-089165UNIT,MIO_T;DS-089165AIRPOL,GHG;&rankName1=UNIT_1_2_-1_2&rankName2=AIRPOL_1_2_-1_2&rankName3=INDICATORS_1_2_-1_2&rankName4=TIME_1_0_0_0&rankName5=GEO_1_2_0_0&rankName6=AIREMSECT_1_2_0_1&rStp=&cStp=&rDCh=&cDCh=&rDM=true&cDM=true&footnes=false&empty=false&wai=false&time_mode=NONE&time_most_recent=false&lang=EN&cfo=%23%23%23.%23%23%23%2C%23%23%23" ],
+              ["European Commission", "https://ec.europa.eu/clima/sites/clima/files/ets/registry/docs/verified_emissions_2016_en.xlsx" ]
+            ]
 ---
 
 ## Jak číst tento graf a co znamenají jednotlivé sektory?

--- a/_infografiky/emise/emise-cr-detail.md
+++ b/_infografiky/emise/emise-cr-detail.md
@@ -4,10 +4,9 @@ title:      "Emise skleníkových plynů ČR (detailní)"
 slug:       emise-cr-detail
 weight:     4
 tags:       [ emise, CO2, CR ]
-data:       "https://docs.google.com/spreadsheets/d/1igCIcrkec7J6sfp4L4lGMzeDS4Mf-o7GZOxduZC8-pc/edit?usp=sharing"
 caption:    "Rozložení celkových emisí skleníkových plynů (v tunách CO<sub>2</sub> ekvivalentu) v ČR za jeden rok v jednotlivých sektorech lidské činnosti. Roční objem emisí České republiky je 130,35 mil. tun (údaj z roku 2016). V přepočtu na obyvatele to je 12,3 tCO<sub>2</sub>eq/obyvatele."
-src:	    "Zdrojová data Eurostat"
-srclink:    "http://appsso.eurostat.ec.europa.eu/nui/show.do?query=BOOKMARK_DS-089165_QID_20FB36E9_UID_-3F171EB0&layout=GEO,L,X,0;AIREMSECT,B,Y,0;UNIT,L,Z,0;AIRPOL,L,Z,1;TIME,C,Z,2;INDICATORS,C,Z,3;&zSelection=DS-089165INDICATORS,OBS_FLAG;DS-089165TIME,2016;DS-089165UNIT,MIO_T;DS-089165AIRPOL,GHG;&rankName1=UNIT_1_2_-1_2&rankName2=AIRPOL_1_2_-1_2&rankName3=INDICATORS_1_2_-1_2&rankName4=TIME_1_0_0_0&rankName5=GEO_1_2_0_0&rankName6=AIREMSECT_1_2_0_1&rStp=&cStp=&rDCh=&cDCh=&rDM=true&cDM=true&footnes=false&empty=false&wai=false&time_mode=NONE&time_most_recent=false&lang=EN&cfo=%23%23%23.%23%23%23%2C%23%23%23"
+data-our:   "https://docs.google.com/spreadsheets/d/1igCIcrkec7J6sfp4L4lGMzeDS4Mf-o7GZOxduZC8-pc/edit?usp=sharing"
+data-orig:	[ [ "Zdrojová data Eurostat", "http://appsso.eurostat.ec.europa.eu/nui/show.do?query=BOOKMARK_DS-089165_QID_20FB36E9_UID_-3F171EB0&layout=GEO,L,X,0;AIREMSECT,B,Y,0;UNIT,L,Z,0;AIRPOL,L,Z,1;TIME,C,Z,2;INDICATORS,C,Z,3;&zSelection=DS-089165INDICATORS,OBS_FLAG;DS-089165TIME,2016;DS-089165UNIT,MIO_T;DS-089165AIRPOL,GHG;&rankName1=UNIT_1_2_-1_2&rankName2=AIRPOL_1_2_-1_2&rankName3=INDICATORS_1_2_-1_2&rankName4=TIME_1_0_0_0&rankName5=GEO_1_2_0_0&rankName6=AIREMSECT_1_2_0_1&rStp=&cStp=&rDCh=&cDCh=&rDM=true&cDM=true&footnes=false&empty=false&wai=false&time_mode=NONE&time_most_recent=false&lang=EN&cfo=%23%23%23.%23%23%23%2C%23%23%23" ] ]
 ---
 
 ## Jak číst tento graf a co znamenají jednotlivé sektory?

--- a/_infografiky/emise/emise-cr.md
+++ b/_infografiky/emise/emise-cr.md
@@ -6,7 +6,10 @@ weight:     5
 tags:       [ emise, CO2, CR ]
 caption:    "Rozložení celkových emisí skleníkových plynů (v tunách CO<sub>2</sub> ekvivalentu) v ČR za jeden rok v jednotlivých sektorech lidské činnosti. Roční objem emisí České republiky je 130,35 mil. tun (údaj z roku 2016). V přepočtu na obyvatele to je 12,3 tCO<sub>2</sub>eq/obyvatele."
 data-our:   "https://docs.google.com/spreadsheets/d/1igCIcrkec7J6sfp4L4lGMzeDS4Mf-o7GZOxduZC8-pc/edit?usp=sharing"
-data-orig:  [ [ "Zdrojová data Eurostat", "http://appsso.eurostat.ec.europa.eu/nui/show.do?query=BOOKMARK_DS-089165_QID_20FB36E9_UID_-3F171EB0&layout=GEO,L,X,0;AIREMSECT,B,Y,0;UNIT,L,Z,0;AIRPOL,L,Z,1;TIME,C,Z,2;INDICATORS,C,Z,3;&zSelection=DS-089165INDICATORS,OBS_FLAG;DS-089165TIME,2016;DS-089165UNIT,MIO_T;DS-089165AIRPOL,GHG;&rankName1=UNIT_1_2_-1_2&rankName2=AIRPOL_1_2_-1_2&rankName3=INDICATORS_1_2_-1_2&rankName4=TIME_1_0_0_0&rankName5=GEO_1_2_0_0&rankName6=AIREMSECT_1_2_0_1&rStp=&cStp=&rDCh=&cDCh=&rDM=true&cDM=true&footnes=false&empty=false&wai=false&time_mode=NONE&time_most_recent=false&lang=EN&cfo=%23%23%23.%23%23%23%2C%23%23%23" ] ]
+data-orig:  [
+              [ "Eurostat", "http://appsso.eurostat.ec.europa.eu/nui/show.do?query=BOOKMARK_DS-089165_QID_20FB36E9_UID_-3F171EB0&layout=GEO,L,X,0;AIREMSECT,B,Y,0;UNIT,L,Z,0;AIRPOL,L,Z,1;TIME,C,Z,2;INDICATORS,C,Z,3;&zSelection=DS-089165INDICATORS,OBS_FLAG;DS-089165TIME,2016;DS-089165UNIT,MIO_T;DS-089165AIRPOL,GHG;&rankName1=UNIT_1_2_-1_2&rankName2=AIRPOL_1_2_-1_2&rankName3=INDICATORS_1_2_-1_2&rankName4=TIME_1_0_0_0&rankName5=GEO_1_2_0_0&rankName6=AIREMSECT_1_2_0_1&rStp=&cStp=&rDCh=&cDCh=&rDM=true&cDM=true&footnes=false&empty=false&wai=false&time_mode=NONE&time_most_recent=false&lang=EN&cfo=%23%23%23.%23%23%23%2C%23%23%23" ],
+              ["European Commission", "https://ec.europa.eu/clima/sites/clima/files/ets/registry/docs/verified_emissions_2016_en.xlsx" ]
+            ]
 ---
 
 ## Jak číst tento graf a co znamenají jednotlivé sektory?

--- a/_infografiky/emise/emise-cr.md
+++ b/_infografiky/emise/emise-cr.md
@@ -7,8 +7,7 @@ tags:       [ emise, CO2, CR ]
 caption:    "Rozložení celkových emisí skleníkových plynů (v tunách CO<sub>2</sub> ekvivalentu) v ČR za jeden rok v jednotlivých sektorech lidské činnosti. Roční objem emisí České republiky je 130,35 mil. tun (údaj z roku 2016). V přepočtu na obyvatele to je 12,3 tCO<sub>2</sub>eq/obyvatele."
 data-our:   "https://docs.google.com/spreadsheets/d/1igCIcrkec7J6sfp4L4lGMzeDS4Mf-o7GZOxduZC8-pc/edit?usp=sharing"
 data-orig:  [
-              [ "Eurostat", "http://appsso.eurostat.ec.europa.eu/nui/show.do?query=BOOKMARK_DS-089165_QID_20FB36E9_UID_-3F171EB0&layout=GEO,L,X,0;AIREMSECT,B,Y,0;UNIT,L,Z,0;AIRPOL,L,Z,1;TIME,C,Z,2;INDICATORS,C,Z,3;&zSelection=DS-089165INDICATORS,OBS_FLAG;DS-089165TIME,2016;DS-089165UNIT,MIO_T;DS-089165AIRPOL,GHG;&rankName1=UNIT_1_2_-1_2&rankName2=AIRPOL_1_2_-1_2&rankName3=INDICATORS_1_2_-1_2&rankName4=TIME_1_0_0_0&rankName5=GEO_1_2_0_0&rankName6=AIREMSECT_1_2_0_1&rStp=&cStp=&rDCh=&cDCh=&rDM=true&cDM=true&footnes=false&empty=false&wai=false&time_mode=NONE&time_most_recent=false&lang=EN&cfo=%23%23%23.%23%23%23%2C%23%23%23" ],
-              ["European Commission", "https://ec.europa.eu/clima/sites/clima/files/ets/registry/docs/verified_emissions_2016_en.xlsx" ]
+              [ "Zdrojová data Eurostat", "http://appsso.eurostat.ec.europa.eu/nui/show.do?query=BOOKMARK_DS-089165_QID_20FB36E9_UID_-3F171EB0&layout=GEO,L,X,0;AIREMSECT,B,Y,0;UNIT,L,Z,0;AIRPOL,L,Z,1;TIME,C,Z,2;INDICATORS,C,Z,3;&zSelection=DS-089165INDICATORS,OBS_FLAG;DS-089165TIME,2016;DS-089165UNIT,MIO_T;DS-089165AIRPOL,GHG;&rankName1=UNIT_1_2_-1_2&rankName2=AIRPOL_1_2_-1_2&rankName3=INDICATORS_1_2_-1_2&rankName4=TIME_1_0_0_0&rankName5=GEO_1_2_0_0&rankName6=AIREMSECT_1_2_0_1&rStp=&cStp=&rDCh=&cDCh=&rDM=true&cDM=true&footnes=false&empty=false&wai=false&time_mode=NONE&time_most_recent=false&lang=EN&cfo=%23%23%23.%23%23%23%2C%23%23%23" ],
             ]
 ---
 

--- a/_infografiky/emise/emise-cr.md
+++ b/_infografiky/emise/emise-cr.md
@@ -4,10 +4,9 @@ title:      "Emise skleníkových plynů ČR"
 slug:       emise-cr
 weight:     5
 tags:       [ emise, CO2, CR ]
-data:       "https://docs.google.com/spreadsheets/d/1igCIcrkec7J6sfp4L4lGMzeDS4Mf-o7GZOxduZC8-pc/edit?usp=sharing"
 caption:    "Rozložení celkových emisí skleníkových plynů (v tunách CO<sub>2</sub> ekvivalentu) v ČR za jeden rok v jednotlivých sektorech lidské činnosti. Roční objem emisí České republiky je 130,35 mil. tun (údaj z roku 2016). V přepočtu na obyvatele to je 12,3 tCO<sub>2</sub>eq/obyvatele."
-src:	    "Zdrojová data Eurostat"
-srclink:    "http://appsso.eurostat.ec.europa.eu/nui/show.do?query=BOOKMARK_DS-089165_QID_20FB36E9_UID_-3F171EB0&layout=GEO,L,X,0;AIREMSECT,B,Y,0;UNIT,L,Z,0;AIRPOL,L,Z,1;TIME,C,Z,2;INDICATORS,C,Z,3;&zSelection=DS-089165INDICATORS,OBS_FLAG;DS-089165TIME,2016;DS-089165UNIT,MIO_T;DS-089165AIRPOL,GHG;&rankName1=UNIT_1_2_-1_2&rankName2=AIRPOL_1_2_-1_2&rankName3=INDICATORS_1_2_-1_2&rankName4=TIME_1_0_0_0&rankName5=GEO_1_2_0_0&rankName6=AIREMSECT_1_2_0_1&rStp=&cStp=&rDCh=&cDCh=&rDM=true&cDM=true&footnes=false&empty=false&wai=false&time_mode=NONE&time_most_recent=false&lang=EN&cfo=%23%23%23.%23%23%23%2C%23%23%23"
+data-our:   "https://docs.google.com/spreadsheets/d/1igCIcrkec7J6sfp4L4lGMzeDS4Mf-o7GZOxduZC8-pc/edit?usp=sharing"
+data-orig:  [ [ "Zdrojová data Eurostat", "http://appsso.eurostat.ec.europa.eu/nui/show.do?query=BOOKMARK_DS-089165_QID_20FB36E9_UID_-3F171EB0&layout=GEO,L,X,0;AIREMSECT,B,Y,0;UNIT,L,Z,0;AIRPOL,L,Z,1;TIME,C,Z,2;INDICATORS,C,Z,3;&zSelection=DS-089165INDICATORS,OBS_FLAG;DS-089165TIME,2016;DS-089165UNIT,MIO_T;DS-089165AIRPOL,GHG;&rankName1=UNIT_1_2_-1_2&rankName2=AIRPOL_1_2_-1_2&rankName3=INDICATORS_1_2_-1_2&rankName4=TIME_1_0_0_0&rankName5=GEO_1_2_0_0&rankName6=AIREMSECT_1_2_0_1&rStp=&cStp=&rDCh=&cDCh=&rDM=true&cDM=true&footnes=false&empty=false&wai=false&time_mode=NONE&time_most_recent=false&lang=EN&cfo=%23%23%23.%23%23%23%2C%23%23%23" ] ]
 ---
 
 ## Jak číst tento graf a co znamenají jednotlivé sektory?

--- a/_infografiky/emise/emise-eu-poradi.md
+++ b/_infografiky/emise/emise-eu-poradi.md
@@ -4,10 +4,9 @@ title:      "Pořadí států EU podle emisí skleníkových plynů"
 slug:       emise-eu-poradi
 weight:     2
 tags:       [ emise, EU, CO2 ]
-data:       "https://docs.google.com/spreadsheets/d/1ldy3l-W0HDG1cHK393_rQC5pGXIWbVw94Dh3ie4aEI8/edit#gid=1205604728"
 caption:    "Vztah mezi celkovými ročními emisemi jednotlivých států EU a jejich přepočtem na obyvatele"
-src:	    "Zdrojová data Eurostat"
-srclink:    "http://appsso.eurostat.ec.europa.eu/nui/show.do?query=BOOKMARK_DS-089165_QID_20FB36E9_UID_-3F171EB0&layout=GEO,L,X,0;AIREMSECT,B,Y,0;UNIT,L,Z,0;AIRPOL,L,Z,1;TIME,C,Z,2;INDICATORS,C,Z,3;&zSelection=DS-089165INDICATORS,OBS_FLAG;DS-089165TIME,2016;DS-089165UNIT,MIO_T;DS-089165AIRPOL,GHG;&rankName1=UNIT_1_2_-1_2&rankName2=AIRPOL_1_2_-1_2&rankName3=INDICATORS_1_2_-1_2&rankName4=TIME_1_0_0_0&rankName5=GEO_1_2_0_0&rankName6=AIREMSECT_1_2_0_1&rStp=&cStp=&rDCh=&cDCh=&rDM=true&cDM=true&footnes=false&empty=false&wai=false&time_mode=NONE&time_most_recent=false&lang=EN&cfo=%23%23%23.%23%23%23%2C%23%23%23"
+data-our:   "https://docs.google.com/spreadsheets/d/1ldy3l-W0HDG1cHK393_rQC5pGXIWbVw94Dh3ie4aEI8/edit#gid=1205604728"
+data-orig:  [ [ "Zdrojová data Eurostat", "http://appsso.eurostat.ec.europa.eu/nui/show.do?query=BOOKMARK_DS-089165_QID_20FB36E9_UID_-3F171EB0&layout=GEO,L,X,0;AIREMSECT,B,Y,0;UNIT,L,Z,0;AIRPOL,L,Z,1;TIME,C,Z,2;INDICATORS,C,Z,3;&zSelection=DS-089165INDICATORS,OBS_FLAG;DS-089165TIME,2016;DS-089165UNIT,MIO_T;DS-089165AIRPOL,GHG;&rankName1=UNIT_1_2_-1_2&rankName2=AIRPOL_1_2_-1_2&rankName3=INDICATORS_1_2_-1_2&rankName4=TIME_1_0_0_0&rankName5=GEO_1_2_0_0&rankName6=AIREMSECT_1_2_0_1&rStp=&cStp=&rDCh=&cDCh=&rDM=true&cDM=true&footnes=false&empty=false&wai=false&time_mode=NONE&time_most_recent=false&lang=EN&cfo=%23%23%23.%23%23%23%2C%23%23%23" ] ]
 ---
 
 ## Jak číst tento graf?

--- a/_infografiky/emise/emise-eu.md
+++ b/_infografiky/emise/emise-eu.md
@@ -4,10 +4,9 @@ title:      "Emise skleníkových plynů EU"
 slug:       emise-eu
 weight:     1
 tags:       [ emise, EU, CO2 ]
-data:       "https://docs.google.com/spreadsheets/d/1ldy3l-W0HDG1cHK393_rQC5pGXIWbVw94Dh3ie4aEI8/edit#gid=1205604728"
 caption:    "Poměrové srovnání ročních emisí 28 členských států EU a přepočet na obyvatele"
-src:	    "Zdrojová data Eurostat"
-srclink:    "http://appsso.eurostat.ec.europa.eu/nui/show.do?query=BOOKMARK_DS-089165_QID_20FB36E9_UID_-3F171EB0&layout=GEO,L,X,0;AIREMSECT,B,Y,0;UNIT,L,Z,0;AIRPOL,L,Z,1;TIME,C,Z,2;INDICATORS,C,Z,3;&zSelection=DS-089165INDICATORS,OBS_FLAG;DS-089165TIME,2016;DS-089165UNIT,MIO_T;DS-089165AIRPOL,GHG;&rankName1=UNIT_1_2_-1_2&rankName2=AIRPOL_1_2_-1_2&rankName3=INDICATORS_1_2_-1_2&rankName4=TIME_1_0_0_0&rankName5=GEO_1_2_0_0&rankName6=AIREMSECT_1_2_0_1&rStp=&cStp=&rDCh=&cDCh=&rDM=true&cDM=true&footnes=false&empty=false&wai=false&time_mode=NONE&time_most_recent=false&lang=EN&cfo=%23%23%23.%23%23%23%2C%23%23%23"
+data-our:   "https://docs.google.com/spreadsheets/d/1ldy3l-W0HDG1cHK393_rQC5pGXIWbVw94Dh3ie4aEI8/edit#gid=1205604728"
+data-orig:  [ [ "Zdrojová data Eurostat", "http://appsso.eurostat.ec.europa.eu/nui/show.do?query=BOOKMARK_DS-089165_QID_20FB36E9_UID_-3F171EB0&layout=GEO,L,X,0;AIREMSECT,B,Y,0;UNIT,L,Z,0;AIRPOL,L,Z,1;TIME,C,Z,2;INDICATORS,C,Z,3;&zSelection=DS-089165INDICATORS,OBS_FLAG;DS-089165TIME,2016;DS-089165UNIT,MIO_T;DS-089165AIRPOL,GHG;&rankName1=UNIT_1_2_-1_2&rankName2=AIRPOL_1_2_-1_2&rankName3=INDICATORS_1_2_-1_2&rankName4=TIME_1_0_0_0&rankName5=GEO_1_2_0_0&rankName6=AIREMSECT_1_2_0_1&rStp=&cStp=&rDCh=&cDCh=&rDM=true&cDM=true&footnes=false&empty=false&wai=false&time_mode=NONE&time_most_recent=false&lang=EN&cfo=%23%23%23.%23%23%23%2C%23%23%23" ] ]
 ---
 
 ## Jak číst tento graf?

--- a/_infografiky/emise/emise-vybrane-staty.md
+++ b/_infografiky/emise/emise-vybrane-staty.md
@@ -4,10 +4,9 @@ title:      "Srovnání emisí skleníkových plynů"
 slug:       emise-vybrane-staty
 weight:     3
 tags:       [ emise, EU, CO2 ]
-data:       "https://docs.google.com/spreadsheets/d/1ldy3l-W0HDG1cHK393_rQC5pGXIWbVw94Dh3ie4aEI8/edit?usp=sharing"
 caption:    "Srovnání emisí některých zemí EU přepočtených na obyvatele (jednotka jsou tuny CO<sub>2</sub>eq na obyvatele), zobrazeny podle sektorů."
-src:	    "Zdrojová data Eurostat"
-srclink:    "http://appsso.eurostat.ec.europa.eu/nui/show.do?query=BOOKMARK_DS-089165_QID_20FB36E9_UID_-3F171EB0&layout=GEO,L,X,0;AIREMSECT,B,Y,0;UNIT,L,Z,0;AIRPOL,L,Z,1;TIME,C,Z,2;INDICATORS,C,Z,3;&zSelection=DS-089165INDICATORS,OBS_FLAG;DS-089165TIME,2016;DS-089165UNIT,MIO_T;DS-089165AIRPOL,GHG;&rankName1=UNIT_1_2_-1_2&rankName2=AIRPOL_1_2_-1_2&rankName3=INDICATORS_1_2_-1_2&rankName4=TIME_1_0_0_0&rankName5=GEO_1_2_0_0&rankName6=AIREMSECT_1_2_0_1&rStp=&cStp=&rDCh=&cDCh=&rDM=true&cDM=true&footnes=false&empty=false&wai=false&time_mode=NONE&time_most_recent=false&lang=EN&cfo=%23%23%23.%23%23%23%2C%23%23%23"
+data-our:   "https://docs.google.com/spreadsheets/d/1ldy3l-W0HDG1cHK393_rQC5pGXIWbVw94Dh3ie4aEI8/edit?usp=sharing"
+data-orig:  [ [ "Zdrojová data Eurostat", "http://appsso.eurostat.ec.europa.eu/nui/show.do?query=BOOKMARK_DS-089165_QID_20FB36E9_UID_-3F171EB0&layout=GEO,L,X,0;AIREMSECT,B,Y,0;UNIT,L,Z,0;AIRPOL,L,Z,1;TIME,C,Z,2;INDICATORS,C,Z,3;&zSelection=DS-089165INDICATORS,OBS_FLAG;DS-089165TIME,2016;DS-089165UNIT,MIO_T;DS-089165AIRPOL,GHG;&rankName1=UNIT_1_2_-1_2&rankName2=AIRPOL_1_2_-1_2&rankName3=INDICATORS_1_2_-1_2&rankName4=TIME_1_0_0_0&rankName5=GEO_1_2_0_0&rankName6=AIREMSECT_1_2_0_1&rStp=&cStp=&rDCh=&cDCh=&rDM=true&cDM=true&footnes=false&empty=false&wai=false&time_mode=NONE&time_most_recent=false&lang=EN&cfo=%23%23%23.%23%23%23%2C%23%23%23" ] ]
 ---
 
 ## Co je v grafice zobrazeno?

--- a/_infografiky/teploty/koncentrace-co2.md
+++ b/_infografiky/teploty/koncentrace-co2.md
@@ -4,10 +4,11 @@ title:      "Vývoj koncentrace CO<sub>2</sub> v historii"
 slug:       koncentrace-co2
 weight:     3
 tags:       [ teploty, CO2, svet ]
-data:       "https://docs.google.com/spreadsheets/d/1fV9lD8vdVRpijeswxnuqDnbRQOXayiP_mTLZvDOflmQ/edit?usp=sharing"
 caption:    "Od průmyslové revoluce rostou koncentrace oxidu uhličitého vysoko nad hodnoty, které byly na planetě během posledních 800&thinsp;000&nbsp;let a výrazně zvyšují skleníkový efekt a způsobují globální oteplování. Data pochází z analýzy ledovcových vrtů EPICA v Antarktidě a z přímých měření na Mauna Loa, Hawai."
-src:	    "Zdrojová data"
-srclink:    "http://scrippsco2.ucsd.edu/data/atmospheric_co2/icecore_merged_products"
+data-our:   "https://docs.google.com/spreadsheets/d/1fV9lD8vdVRpijeswxnuqDnbRQOXayiP_mTLZvDOflmQ/edit?usp=sharing"
+data-orig:	[ [ "EPICA", "ftp://ftp.ncdc.noaa.gov/pub/data/paleo/icecore/antarctica/epica_domec/edc-co2-2008.xls" ]
+            , [ "Scripps", "http://scrippsco2.ucsd.edu/data/atmospheric_co2/icecore_merged_products" ]
+            , [ "Scripps CO<sub>2</sub> program", "https://scripps.ucsd.edu/programs/keelingcurve/" ] ]
 ---
 
 ## Jak číst tento graf?

--- a/_infografiky/teploty/teplota-cr-mesice.md
+++ b/_infografiky/teploty/teplota-cr-mesice.md
@@ -4,10 +4,9 @@ title:      "Srovnání průměrné teploty v ČR v jednotlivých měsících"
 slug:       teplota-cr-mesice
 weight:     3
 tags:       [ teploty ]
-data:       "https://docs.google.com/spreadsheets/d/14eph67uGIQJgEBSmvWAufdRY49sI3JFq9G9_lH8G7h4/edit?usp=sharing"
 caption:    "Srovnání teplot jednotlivých měsíců pětiletky 1961–1965 a 2014–2018. Průměrná roční teplota se od roku 1961 zvýšila o 2 °C, ale oteplení se v různých měsících liší. Největší změny v teplotě se udály v prosinci, lednu, červenci a srpnu."
-src:	    "Zdrojová data ČHMÚ"
-srclink:    "http://portal.chmi.cz/historicka-data/pocasi/uzemni-teploty"
+data-our:   "https://docs.google.com/spreadsheets/d/14eph67uGIQJgEBSmvWAufdRY49sI3JFq9G9_lH8G7h4/edit?usp=sharing"
+data-orig:	[ [ "Zdrojová data ČHMÚ", "http://portal.chmi.cz/historicka-data/pocasi/uzemni-teploty" ] ]
 
 ---
 

--- a/_infografiky/teploty/teplota-cr.md
+++ b/_infografiky/teploty/teplota-cr.md
@@ -4,10 +4,9 @@ title:      "Průměrná roční teplota v ČR"
 slug:       teplota-cr
 weight:     1
 tags:       [ teploty ]
-data:       "https://docs.google.com/spreadsheets/d/14eph67uGIQJgEBSmvWAufdRY49sI3JFq9G9_lH8G7h4/edit?usp=sharing"
 caption:    "Průměrná roční teplota v České republice narostla za posledních 60 let o 2 °C."
-src:	    "Zdrojová data ČHMÚ"
-srclink:    "http://portal.chmi.cz/historicka-data/pocasi/uzemni-teploty"
+data-our:   "https://docs.google.com/spreadsheets/d/14eph67uGIQJgEBSmvWAufdRY49sI3JFq9G9_lH8G7h4/edit?usp=sharing"
+data-orig:	[ [ "Zdrojová data ČHMÚ", "http://portal.chmi.cz/historicka-data/pocasi/uzemni-teploty" ] ]
 ---
 
 ## Další komentáře a odkazy

--- a/_infografiky/teploty/trend-teplot-cr.md
+++ b/_infografiky/teploty/trend-teplot-cr.md
@@ -4,10 +4,9 @@ title:      "Trendy nárůstu teploty v ČR v jednotlivých měsících"
 slug:       trend-teplot-cr
 weight:     4
 tags:       [ teploty ]
-data:       "https://docs.google.com/spreadsheets/d/14eph67uGIQJgEBSmvWAufdRY49sI3JFq9G9_lH8G7h4/edit?usp=sharing"
 caption:    "Průměrná roční teplota v České republice narostla za posledních 60 let o 2 °C. Trendy v oteplování jednotlivých měsíců jsou různé. Největší nárůst teplot je v lednu, červenci a srpnu &ndash; tyto měsíce se od roku 1960 oteplily o více než 2,6 °C"
-src:	    "Zdrojová data ČHMÚ"
-srclink:    "http://portal.chmi.cz/historicka-data/pocasi/uzemni-teploty"
+data-our:   "https://docs.google.com/spreadsheets/d/14eph67uGIQJgEBSmvWAufdRY49sI3JFq9G9_lH8G7h4/edit?usp=sharing"
+data-orig:	[ [ "Zdrojová data ČHMÚ", "http://portal.chmi.cz/historicka-data/pocasi/uzemni-teploty" ] ]
 ---
 
 ## Další komentáře a odkazy

--- a/_infografiky/teploty/vyvoj-teplotni-anomalie.md
+++ b/_infografiky/teploty/vyvoj-teplotni-anomalie.md
@@ -4,10 +4,9 @@ title:      "Vývoj průměrné světové teplotní anomálie"
 slug:       vyvoj-teplotni-anomalie
 weight:     2
 tags:       [ teploty ]
-data:       "https://docs.google.com/spreadsheets/d/1dIK4lqpfGxr0Ea_KT_WmR6GpB2nc2Y9ylYf_3TBu95M/edit?usp=sharing"
 caption:    "Planeta je nyní o 0,8–1,0 °C teplejší než v letech 1951–1980. To je však průměrná hodnota teplotní anomálie pro celou planetu – většina míst na severní polokouli je dnes oproti referenčnímu období teplejší o 2–3 °C."
-src:	      "Zdrojová data NASA"
-srclink:    "https://data.giss.nasa.gov/gistemp/"
+data-our:   "https://docs.google.com/spreadsheets/d/1dIK4lqpfGxr0Ea_KT_WmR6GpB2nc2Y9ylYf_3TBu95M/edit?usp=sharing"
+data-orig:  [ [ "Zdrojová data NASA", "https://data.giss.nasa.gov/gistemp/" ] ]
 ---
 
 ## Co je zobrazeno v grafu

--- a/_layouts/infographic.html
+++ b/_layouts/infographic.html
@@ -25,15 +25,15 @@
               <div class="hide-md">
                 <h2>Ke stažení</h2>
                 <p>Líbí se vám naše infografika? Stáhněte si ji a používejte dál!</p>
-                <div class="btn-group" role="group">
+                <div class="btn-group dropdown" role="group">
                   <a href="{{ download_path }}.pdf" id="infographic-pdf" class="btn btn-primary" download>PDF</a>
                   <a href="{{ download_path }}.svg" id="infographic-svg" class="btn btn-primary" download>SVG</a>
-                    <button class="btn btn-primary dropdown-toggle" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">PNG</button>
-                    <div class="dropdown-menu dropdown-links" aria-labelledby="dropdownMenuLink">
-                        <a class="dropdown-item" id="infographic-png-3" href="{{ download_path }}_6000.png" download>6000 x 4000 px</a>
-                        <a class="dropdown-item" id="infographic-png-2" href="{{ download_path }}_1920.png" download>1920 x 1080 px</a>
-                        <a class="dropdown-item" id="infographic-png-1" href="{{ download_path }}_1200.png" download>1200 x 900 px</a>
-                    </div>
+                  <button class="btn btn-primary dropdown-toggle" role="button" id="dropdownPNGselection" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">PNG</button>
+                  <div class="dropdown-menu dropdown-links" aria-labelledby="dropdownPNGselection">
+                      <a class="dropdown-item" id="infographic-png-3" href="{{ download_path }}_6000.png" download>6000 x 4000 px</a>
+                      <a class="dropdown-item" id="infographic-png-2" href="{{ download_path }}_1920.png" download>1920 x 1080 px</a>
+                      <a class="dropdown-item" id="infographic-png-1" href="{{ download_path }}_1200.png" download>1200 x 900 px</a>
+                  </div>
                 </div>
                 <hr/>
               </div>
@@ -41,8 +41,20 @@
                 <h2>Podkladová data</h2>
                 <p>Chcete vidět konkrétní čísla? Stáhněte si náš zpracovaný dataset, nebo ten původní, ze kterého vycházíme.</p>
               </div>
-                <a href="{{ page.data }}" target="_blank" id="data-our" class="btn btn-primary" role="button">Naše zpracovaná data</a>
-                <a href="{{ page.srclink }}" target="_blank" id="data-original" class="btn btn-primary" role="button">{{page.src}}</a>
+                <a href="{{ page.data-our }}" target="_blank" id="data-our" class="btn btn-primary" role="button">Naše zpracovaná data</a>
+                {% if page.data-orig.size == 1 %}
+                <a href="{{ page.data-orig[0][1] }}" target="_blank" id="data-original" class="btn btn-primary" role="button">{{ page.data-orig[0][0] }}</a>
+                {% else %}
+                <div class="dropdown">
+                  <button class="btn btn-primary dropdown-toggle" role="button" id="dropdownDataSources" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Zdrojová data</button>
+                  <div class="dropdown-menu dropdown-links" aria-labelledby="dropdownDataSources">
+                    {% assign numDataSources = page.data-orig.size | minus: 1 %}
+                    {% for i in (0..numDataSources) %}
+                    <a class="dropdown-item" id="data-original-{{ i }}" href="{{ page.data-orig[i][1] }}" target="_blank">{{ page.data-orig[i][0] }}</a>
+                    {% endfor %}
+                  </div>
+                </div>
+                {% endif %}
               <div class="hide-md">
                 <hr/>
                 <h2>Sdílení</h2>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -273,7 +273,6 @@ p.caption {
 }
 
 .dropdown-links a {
-    font-size: 1.4rem;
     text-decoration: none;
 }
 


### PR DESCRIPTION
* Vo vetve `vice-zdroju-dat` je vylepsenie, ktore umoznuje, aby povodny sdroj obsahoval viac stranok. Ak je zadana len jedna, zobrazuje sa to tak, ako doteraz. Ak je zadanych viac, zobrazi sa dropdown menu (ako pri rozliseni PNG).
* Zaroven sa menila syntax (pomenovanie) odkazovanych dat, v zdrojovych suboroch sa teraz pouziva intuitivnejsie `data-our` a `data-orig`.
* [x] Presiel som vsetky grafiky, ale viac dat som identifikoval len pre koncentaciu CO2. Tj. treba to pridat do ostatnych, kde je to relevantne.